### PR TITLE
v.0.0.4 sync start/end timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.0.4
+  * Change `sync.py` date windowing start/end dates to provide dates in local `project_timezone` to eliminate error of requesting data for future dates.
+
 ## 0.0.3
   * Adjust `client.py` to add better error handling for read timeouts.
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mixpanel',
-      version='0.0.3',
+      version='0.0.4',
       description='Singer.io tap for extracting data from the mixpanel API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_mixpanel/sync.py
+++ b/tap_mixpanel/sync.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import timedelta, datetime, timezone
 import math
 import json
 import pytz
@@ -140,8 +140,8 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
     write_schema(catalog, stream_name)
 
     # windowing: loop through date days_interval date windows from last_datetime to now_datetime
-    now_datetime = utils.now()
     tzone = pytz.timezone(project_timezone)
+    now_datetime = datetime.now(tzone)
 
     if bookmark_query_field_from and bookmark_query_field_to:
         # days_interval from config date_window_size, default = 60; passed to function from sync
@@ -187,8 +187,8 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
             # Request dates need to be normalized to project timezone or else errors may occur
             # Errors occur when from_date is > 365 days ago
             #   and when to_date > today (in project timezone)
-            from_date = '{}'.format(tzone.normalize(start_window))[0:10]
-            to_date = '{}'.format(tzone.normalize(end_window))[0:10]
+            from_date = '{}'.format(start_window.astimezone(tzone))[0:10]
+            to_date = '{}'.format(end_window.astimezone(tzone))[0:10]
             LOGGER.info('START Sync for Stream: {}{}'.format(
                 stream_name,
                 ', Date window from: {} to {}'.format(from_date, to_date) \


### PR DESCRIPTION
# Description of change
Change date windowing start/end dates to provide dates in local `project_timezone` to eliminate error of requesting data for future dates.

# Manual QA steps
Ran discovery, sync to target-stitch (initial load and incremental). No issues.
 
# Risks
 Low - tap currently in Alpha testing
 
# Rollback steps
Revert to v.0.0.3
