### PR TITLE
Fix memory leak by not calling response.text

### DIFF
--- a/tap_mixpanel/client.py
+++ b/tap_mixpanel/client.py
@@ -249,12 +249,6 @@ class MixpanelClient(object):
         # export endpoint returns jsonl results; 
         #  other endpoints return json with array of results
         #  jsonlines reference: https://jsonlines.readthedocs.io/en/latest/
-
-        if response.text == '':
-            LOGGER.warning('/export API response empty')
-            yield None
-        else:
-            file_like_object = io.StringIO(response.text)
-            reader = jsonlines.Reader(file_like_object)
-            for record in reader.iter(allow_none=True, skip_empty=True):
-                yield record
+        reader = jsonlines.Reader(response.iter_lines())
+        for record in reader.iter(allow_none=True, skip_empty=True):
+            yield record


### PR DESCRIPTION
# Description of change

Calling `response.text` consumes all the data regardless of the `stream=True` kwarg. For a sufficiently large export, this can cause a memory leak to check something that is superfluous.

# Manual QA steps
 - Ran a leaking example and confirmed the change removes the leak.
 
# Risks
 - We lose a warning log line when we encounter an empty response.
 
# Rollback steps
 - revert this branch
