### PR TITLE
Update exports to be an append-only stream with no pk

### DIFF
--- a/tap_mixpanel/schemas/export.json
+++ b/tap_mixpanel/schemas/export.json
@@ -2,6 +2,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "mp_reserved_insert_id": {
+      "type": ["null", "string"]
+    },
     "event": {
       "type": ["null", "string"]
     },

--- a/tap_mixpanel/schemas/export.json
+++ b/tap_mixpanel/schemas/export.json
@@ -2,9 +2,6 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "mp_reserved_insert_id": {
-      "type": ["null", "string"]
-    },
     "event": {
       "type": ["null", "string"]
     },

--- a/tap_mixpanel/streams.py
+++ b/tap_mixpanel/streams.py
@@ -21,7 +21,7 @@ STREAMS = {
         'path': 'export',
         'data_key': 'results',
         'api_method': 'GET',
-        'key_properties': ['event', 'time', 'distinct_id'],
+        'key_properties': ['mp_reserved_insert_id'],
         'replication_method': 'INCREMENTAL',
         'replication_keys': ['time'],
         'bookmark_query_field_from': 'from_date',

--- a/tap_mixpanel/streams.py
+++ b/tap_mixpanel/streams.py
@@ -21,7 +21,7 @@ STREAMS = {
         'path': 'export',
         'data_key': 'results',
         'api_method': 'GET',
-        'key_properties': ['mp_reserved_insert_id'],
+        'key_properties': [],
         'replication_method': 'INCREMENTAL',
         'replication_keys': ['time'],
         'bookmark_query_field_from': 'from_date',

--- a/tap_mixpanel/sync.py
+++ b/tap_mixpanel/sync.py
@@ -27,7 +27,6 @@ def write_record(stream_name, record, time_extracted):
         singer.messages.write_record(stream_name, record, time_extracted=time_extracted)
     except OSError as err:
         LOGGER.error('OS Error writing record for: {}'.format(stream_name))
-        LOGGER.error('record: {}'.format(record))
         raise err
 
 
@@ -69,7 +68,6 @@ def process_records(catalog, #pylint: disable=too-many-branches
     with metrics.record_counter(stream_name) as counter:
         for record in records:
             # Transform record for Singer.io
-            # LOGGER.info('Process record = {}'.format(record)) # COMMENT OUT
             with Transformer() as transformer:
                 try:
                     transformed_record = transformer.transform(
@@ -78,8 +76,6 @@ def process_records(catalog, #pylint: disable=too-many-branches
                         stream_metadata)
                 except Exception as err:
                     LOGGER.error('Error: {}'.format(err))
-                    LOGGER.error('Error record: {}'.format(json.dumps(
-                        record, sort_keys=True, indent=2)))
                     LOGGER.error(' for schema: {}'.format(json.dumps(
                         schema, sort_keys=True, indent=2)))
                     raise err
@@ -265,7 +261,6 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
                     for record in data:
                         if record and str(record) != '':
                             # transform reocord and append to transformed_data array
-                            # LOGGER.info('record = {}'.format(record)) # COMMENT OUT
                             transformed_record = transform_record(record, stream_name, \
                                 project_timezone)
                             transformed_data.append(transformed_record)
@@ -275,8 +270,6 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
                                 val = transformed_record.get(key)
                                 if val == '' or not val:
                                     LOGGER.error('Error: Missing Key')
-                                    LOGGER.error(' Missing key {} in record: {}'.format(
-                                        key, record))
                                     raise 'Missing Key'
 
                             if len(transformed_data) == limit:
@@ -380,8 +373,6 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
                                 val = transformed_record.get(key)
                                 if val == '' or not val:
                                     LOGGER.error('Error: Missing Key')
-                                    LOGGER.error(' Missing key {} in record: {}'.format(
-                                        key, transformed_record))
                                     raise 'Missing Key'
 
                             # End data record loop

--- a/tests/tap_combined_test.py
+++ b/tests/tap_combined_test.py
@@ -32,9 +32,7 @@ class TapCombinedTest(unittest.TestCase):
         return set(config['streams'].keys())
 
     def expected_sync_streams(self):
-        return set(config['streams'].keys()).difference({
-            'export' # Rate limited, start_date must be recent enough to avoid this
-        })
+        return set(config['streams'].keys())
 
     def expected_pks(self):
         return config['streams']


### PR DESCRIPTION
# Description of change
Update exports to be an append-only stream with no pk - https://stitchdata.atlassian.net/browse/SRCE-3696

# Manual QA steps
 - Manually ran circle tests (added export back to the streams tested)
 - Manually ran check and sync on cloned customer connection which had exports stream selected and re-ran the tap to confirm the schema said no field for the pk
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
