### PR TITLE
Bump version to 1.0.1 to avoid pypi 1.0.0 conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.1
+  * Bumping patch version to avoid conflict with old pypi uploaded version 1.0.0 in May 2017
+
 ## 1.0.0
   * Major version bump intended to release changes from 0.0.6
   * Plus [PR #6 to change export stream to be append-only with no primary key](https://github.com/singer-io/tap-mixpanel/pull/6)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mixpanel',
-      version='1.0.0',
+      version='1.0.1',
       description='Singer.io tap for extracting data from the mixpanel API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
Bump version to 1.0.1 to avoid pypi 1.0.0 conflict

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
