### PR TITLE
Allows tap to continue when encountering a 402 from /engage endpoint

### DIFF
--- a/tap_mixpanel/client.py
+++ b/tap_mixpanel/client.py
@@ -137,8 +137,6 @@ class MixpanelClient(object):
             return True
         elif response.status_code != 200:
             LOGGER.error('Error status_code = {}'.format(response.status_code))
-            import ipdb; ipdb.set_trace()
-            1+1
             raise_for_error(response)
         else:
             return True

--- a/tap_mixpanel/client.py
+++ b/tap_mixpanel/client.py
@@ -129,8 +129,16 @@ class MixpanelClient(object):
         except requests.exceptions.Timeout as err:
             LOGGER.error('TIMEOUT ERROR: {}'.format(err))
             raise ReadTimeoutError
-        if response.status_code != 200:
+
+        if response.status_code == 402:
+            # 402 Payment Requirement does not indicate a permissions or authentication error
+            self.disable_engage_endpoint = True
+            LOGGER.warning('Mixpanel returned a 402 from the Engage API. Engage stream will be skipped.')
+            return True
+        elif response.status_code != 200:
             LOGGER.error('Error status_code = {}'.format(response.status_code))
+            import ipdb; ipdb.set_trace()
+            1+1
             raise_for_error(response)
         else:
             return True

--- a/tap_mixpanel/client.py
+++ b/tap_mixpanel/client.py
@@ -97,6 +97,7 @@ class MixpanelClient(object):
         self.__user_agent = user_agent
         self.__session = requests.Session()
         self.__verified = False
+        self.disable_engage_endpoint = False
 
     def __enter__(self):
         self.__verified = self.check_access()

--- a/tap_mixpanel/schema.py
+++ b/tap_mixpanel/schema.py
@@ -2,6 +2,9 @@ import os
 import json
 from singer import metadata
 from tap_mixpanel.streams import STREAMS
+import singer
+
+LOGGER = singer.get_logger()
 
 # Reference:
 # https://github.com/singer-io/getting-started/blob/master/docs/DISCOVERY_MODE.md#Metadata
@@ -109,6 +112,11 @@ def get_schemas(client, properties_flag):
     field_metadata = {}
 
     for stream_name, stream_metadata in STREAMS.items():
+        # When the client detects disable_engage_endpoint, skip discovering the stream
+        if stream_name == 'engage' and client.disable_engage_endpoint:
+            LOGGER.warning('Mixpanel returned a 402 indicating the Engage endpoint and stream is unavailable. Skipping.')
+            continue
+
         schema = get_schema(client, properties_flag, stream_name)
 
         schemas[stream_name] = schema


### PR DESCRIPTION
# Description of change

A 402 does not indicate that the tap does not have access - only that the engage endpoint cannot be queried due to a payment being required.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
