### PR TITLE
Make date_window_size not required since it has a default value

### DIFF
--- a/tap_mixpanel/__init__.py
+++ b/tap_mixpanel/__init__.py
@@ -16,7 +16,6 @@ LOGGER = singer.get_logger()
 REQUIRED_CONFIG_KEYS = [
     'project_timezone',
     'api_secret',
-    'date_window_size',
     'attribution_window',
     'start_date',
     'user_agent'


### PR DESCRIPTION
# Description of change
Make date_window_size not required since it has a default value of 30.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
