### PR TITLE
Remove page_size param to shorten processing time

### DIFF
--- a/tap_mixpanel/client.py
+++ b/tap_mixpanel/client.py
@@ -116,7 +116,7 @@ class MixpanelClient(object):
             raise Exception('Error: Missing api_secret in tap config.json.')
         headers = {}
         # Endpoint: simple API call to return a single record (org settings) to test access
-        url = 'https://mixpanel.com/api/2.0/engage?page_size=1'
+        url = 'https://mixpanel.com/api/2.0/engage'
         if self.__user_agent:
             headers['User-Agent'] = self.__user_agent
         headers['Accept'] = 'application/json'

--- a/tap_mixpanel/sync.py
+++ b/tap_mixpanel/sync.py
@@ -224,7 +224,7 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
 
             session_id = 'initial'
             if pagination:
-                params['page_size'] = limit
+                params['limit'] = limit
 
             while offset <= total_records and session_id is not None:
                 if pagination and page != 0:


### PR DESCRIPTION
# Description of change
Remove `page_size` param to shorten processing time. This fixes the following issues
* A timeout error because if you have enough data, it takes too long to filter down to one result to return
* A Bad Request error `"must have a page size >= 100. to fetch a small number of users, use \"limit\" instead of \"page_size\".`

# Manual QA steps
 - Ran the tap
 
# Risks
 - Low, we just want this to return with a 200
 
# Rollback steps
 - revert this branch
