### PR TITLE
Add export_events optional param

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ This tap:
   - Bookmark: `time`
   - Bookmark query field: `from_date`, `to_date`
 - Transformations: De-nest `properties` to root-level, re-name properties with leading `$...` to `mp_reserved_...`, convert datetimes from project timezone to UTC.
+- Optional parameters
+  - `export_events` to export only certain events
 
 **[engage](https://developer.mixpanel.com/docs/data-export-api#section-engage)**
 - Endpoint: https://mixpanel.com/api/2.0/engage
@@ -135,7 +137,14 @@ More details may be found in the [Mixpanel API Authentication](https://developer
         "user_agent": "tap-mixpanel <api_user_email@your_company.com>"
     }
     ```
-    
+  
+      If you want to export only certain events from the [Raw export API](https://developer.mixpanel.com/reference/export)
+    then add `export_events` option to the `config.json` and list the required event names:
+
+    ```bash
+   "export_events": ["event_one", "event_two"]
+   ```
+  
     Optionally, also create a `state.json` file. `currently_syncing` is an optional attribute used for identifying the last object to be synced in case the job is interrupted mid-stream. The next run would begin where the last job left off.
 
     ```json


### PR DESCRIPTION
# Description of change

Sometimes you need to filter specific events to export from the Raw export API. Currently this is not possible and exporting all the events can take long time.

This PR adds `export_events` optional parameter into `config.json` to export only certain events from the [Raw export API](https://developer.mixpanel.com/reference/export). The `export_events` parameter takes a list of event names:

```
"export_events": ["event_one", "event_two"]
```

# Manual QA steps

Ran the tap.
 
# Risks
None, the change is fully backward compatibly.
 
# Rollback steps
 - revert this branch
