### PR TITLE
Update query params to paginate correctly

### DIFF
--- a/tap_mixpanel/sync.py
+++ b/tap_mixpanel/sync.py
@@ -224,7 +224,7 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
 
             session_id = 'initial'
             if pagination:
-                params['limit'] = limit
+                params['page_size'] = limit
 
             while offset <= total_records and session_id is not None:
                 if pagination and page != 0:


### PR DESCRIPTION
# Description of change
This PR fixes pagination for the following streams:
- Engage
- Cohort Members

These are the only two streams affected by this change because the tap only adds this query parameter for streams with `pagination: true` in the endpoint config.

# Manual QA steps

I made the same request the tap makes

```
GET https://mixpanel.com/api/2.0/engage?limit=250

{
  "results": [ ... ],
  "page": 0,
  "session_id": "abc123",
  "page_size": 1000
  "total": 250,
  "status": "ok",
  "computed_at": "2021-08-02T16:02:18.291580+00:00"
}
```

I removed all query params and made the request again

```
GET https://mixpanel.com/api/2.0/engage

{
  "results": [ ... ],
  "page": 0,
  "session_id": "abc123",
  "page_size": 1000
  "total": 45678,
  "status": "ok",
  "computed_at": "2021-08-02T16:00:52.624106+00:00"
}
``` 

I tried to change `page_size`

```
GET https://mixpanel.com/api/2.0/engage?page_size=250

{
  "results": [ ... ],
  "page": 0,
  "session_id": "abc123",
  "page_size": 250
  "total": 45678,
  "status": "ok",
  "computed_at": "2021-08-02T16:02:18.291580+00:00"
}
```

To test `cohort_members`, I ran the tap with the change and `cohort_members` selected. The above situation happened for `cohort_members` too.

# Risks
 - Low
 
# Rollback steps
 - revert this branch and bump the version
