### PR TITLE
Bump to v1.3.0 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.0
+  * Add support for EU residency mixpanel data via the `eu_residency` config parameter, which when `'true'` will have the tap extract data from the EU residency endpoint [#39](https://github.com/singer-io/tap-mixpanel/pull/39)
+
 ## 1.2.2
   * Add a timeout on requests [#20](https://github.com/singer-io/tap-mixpanel/pull/20)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mixpanel',
-      version='1.2.2',
+      version='1.3.0',
       description='Singer.io tap for extracting data from the mixpanel API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
Bump to v1.3.0 and update changelog

Included in this release:
* Add support for EU residency mixpanel data via the `eu_residency` config parameter, which when `'true'` will have the tap extract data from the EU residency endpoint [#39](https://github.com/singer-io/tap-mixpanel/pull/39)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
