### PR TITLE
TDL-22865 Add ProtocolError to retryable errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.4.2
+  * Adds ProtocolError to backoff handling [#58](https://github.com/singer-io/tap-mixpanel/pull/58)
+
 ## 1.4.1
   * Implement Request Timeout
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mixpanel',
-      version='1.4.1',
+      version='1.4.2',
       description='Singer.io tap for extracting data from the mixpanel API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_mixpanel/client.py
+++ b/tap_mixpanel/client.py
@@ -6,6 +6,7 @@ import jsonlines
 import requests
 import singer
 from requests.exceptions import ConnectionError, Timeout
+from requests.models import ProtocolError
 from singer import metrics
 
 LOGGER = singer.get_logger()
@@ -137,7 +138,7 @@ class MixpanelClient(object):
         self.__session.close()
 
     @backoff.on_exception(backoff.expo,
-                          (Server5xxError, Server429Error, ReadTimeoutError, ConnectionError, Timeout),
+                          (Server5xxError, Server429Error, ReadTimeoutError, ConnectionError, Timeout, ProtocolError),
                           max_tries=5,
                           factor=2)
     def check_access(self):
@@ -174,7 +175,7 @@ class MixpanelClient(object):
 
     @backoff.on_exception(
         backoff.expo,
-        (Server5xxError, Server429Error, ReadTimeoutError, ConnectionError, Timeout),
+        (Server5xxError, Server429Error, ReadTimeoutError, ConnectionError, Timeout, ProtocolError),
         max_tries=BACKOFF_MAX_TRIES_REQUEST,
         factor=3,
         logger=LOGGER)

--- a/tests/unittests/test_error_handling.py
+++ b/tests/unittests/test_error_handling.py
@@ -385,6 +385,23 @@ class TestMixpanelErrorHandling(unittest.TestCase):
         mock_client = client.MixpanelClient(api_secret="mock_api_secret", api_domain="mock_api_domain", request_timeout=REQUEST_TIMEOUT)
         with self.assertRaises(client.ReadTimeoutError):
             mock_client.check_access()
-    
+
+        # Verify that requests.Session.request is called 5 times
+        self.assertEqual(mock_request.call_count, 5)
+
+
+
+
+class TestMixpanelConnectionResetErrorHandling(unittest.TestCase):
+
+    @mock.patch("requests.Session.request", side_effect=requests.models.ProtocolError)
+    def test_check_access_handle_timeout_error(self, mock_request):
+        '''
+        Check whether the request backoffs properly for `check_access` method for 5 times in case of Timeout error.
+        '''
+        mock_client = client.MixpanelClient(api_secret="mock_api_secret", api_domain="mock_api_domain", request_timeout=REQUEST_TIMEOUT)
+        with self.assertRaises(requests.models.ProtocolError):
+            mock_client.check_access()
+
         # Verify that requests.Session.request is called 5 times
         self.assertEqual(mock_request.call_count, 5)


### PR DESCRIPTION
# Description of change
Adds ProtocolError (eg ("Connection broken: ConnectionResetError(104, 'Connection reset by peer')")) to retryable errors


# Manual QA steps
 - Added new unittests
 
# Risks
 - N/A; uses existing backoff library and logic found in other taps
 
# Rollback steps
 - revert this branch
