### PR TITLE
Tdl 22899 fix integration tests

### DIFF
--- a/tests/tap_tester/base.py
+++ b/tests/tap_tester/base.py
@@ -28,6 +28,7 @@ class TestMixPanelBase(BaseCase):
     FULL_TABLE = "FULL_TABLE"
     API_LIMIT = 250
     TYPE = "platform.mixpanel"
+    OBEYS_START_DATE = "obey-start-date"
     start_date = ""
     end_date = ""
     eu_residency = True
@@ -43,33 +44,40 @@ class TestMixPanelBase(BaseCase):
                 self.PRIMARY_KEYS: set(),
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {'time'},
+                self.OBEYS_START_DATE: True,
             },
             'engage': {
                 self.PRIMARY_KEYS: {"distinct_id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
+                self.OBEYS_START_DATE: False,
             },
             'funnels': {
                 self.PRIMARY_KEYS: {'funnel_id', 'date'},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {'datetime'},
+                self.OBEYS_START_DATE: True,
             },
             'cohorts': {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
+                self.OBEYS_START_DATE: False,
             },
             'cohort_members': {
                 self.PRIMARY_KEYS: {"cohort_id", "distinct_id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
+                self.OBEYS_START_DATE: False,
             },
             'revenue': {
                 self.PRIMARY_KEYS: {"date"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {'datetime'},
+                self.OBEYS_START_DATE: True,
             },
 
             'annotations': {
                 self.PRIMARY_KEYS: {"date"},
-                self.REPLICATION_METHOD: self.FULL_TABLE
+                self.REPLICATION_METHOD: self.FULL_TABLE,
+                self.OBEYS_START_DATE: False,
             }
         }
 

--- a/tests/tap_tester/base.py
+++ b/tests/tap_tester/base.py
@@ -28,7 +28,6 @@ class TestMixPanelBase(BaseCase):
     FULL_TABLE = "FULL_TABLE"
     API_LIMIT = 250
     TYPE = "platform.mixpanel"
-    OBEYS_START_DATE = "obey-start-date"
     start_date = ""
     end_date = ""
     eu_residency = True
@@ -44,40 +43,33 @@ class TestMixPanelBase(BaseCase):
                 self.PRIMARY_KEYS: set(),
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {'time'},
-                self.OBEYS_START_DATE: True,
             },
             'engage': {
                 self.PRIMARY_KEYS: {"distinct_id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
-                self.OBEYS_START_DATE: False,
             },
             'funnels': {
                 self.PRIMARY_KEYS: {'funnel_id', 'date'},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {'datetime'},
-                self.OBEYS_START_DATE: True,
             },
             'cohorts': {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
-                self.OBEYS_START_DATE: False,
             },
             'cohort_members': {
                 self.PRIMARY_KEYS: {"cohort_id", "distinct_id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
-                self.OBEYS_START_DATE: False,
             },
             'revenue': {
                 self.PRIMARY_KEYS: {"date"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {'datetime'},
-                self.OBEYS_START_DATE: True,
             },
 
             'annotations': {
                 self.PRIMARY_KEYS: {"date"},
-                self.REPLICATION_METHOD: self.FULL_TABLE,
-                self.OBEYS_START_DATE: False,
+                self.REPLICATION_METHOD: self.FULL_TABLE
             }
         }
 

--- a/tests/tap_tester/test_automatic_fields.py
+++ b/tests/tap_tester/test_automatic_fields.py
@@ -60,8 +60,3 @@ class MixPanelAutomaticFieldsTest(TestMixPanelBase):
         """Automatic fields test for standard server"""
         self.eu_residency = False
         self.automatic_fields_test_run()
-
-    def test_eu_auto_fields(self):
-        """Automatic fields test for EU recidency server"""
-        self.eu_residency = True
-        self.automatic_fields_test_run()

--- a/tests/tap_tester/test_bookmark.py
+++ b/tests/tap_tester/test_bookmark.py
@@ -173,8 +173,3 @@ class MixPanelBookMarkTest(TestMixPanelBase):
         """Bookmark test for standard server"""
         self.eu_residency = False
         self.bookmark_test_run()
-
-    def test_eu_bookmarks(self):
-        """Bookmark test for EU recidency server"""
-        self.eu_residency = True
-        self.bookmark_test_run()

--- a/tests/tap_tester/test_discovery.py
+++ b/tests/tap_tester/test_discovery.py
@@ -1,6 +1,5 @@
 import re
-from tap_tester import menagerie, connections
-from tap_tester.logger import LOGGER
+from tap_tester import menagerie, connections, LOGGER
 
 from base import TestMixPanelBase
 
@@ -89,6 +88,13 @@ class MixPanelDiscoverTest(TestMixPanelBase):
                 # verify there is only 1 top level breadcrumb in metadata
                 self.assertEqual(len(stream_properties), 1,
                                  logging='asserting there is only 1 top level breadcrumb in metadata')
+
+                # Verify there is no duplicate metadata entries
+                self.assertEqual(
+                    len(actual_fields),
+                    len(set(actual_fields)),
+                    msg="Duplicates in the fields retrieved",
+                )
 
                 # verify that if there is a replication key we are doing INCREMENTAL otherwise FULL
                 if actual_replication_keys:

--- a/tests/tap_tester/test_discovery.py
+++ b/tests/tap_tester/test_discovery.py
@@ -89,13 +89,6 @@ class MixPanelDiscoverTest(TestMixPanelBase):
                 self.assertEqual(len(stream_properties), 1,
                                  logging='asserting there is only 1 top level breadcrumb in metadata')
 
-                # Verify there is no duplicate metadata entries
-                self.assertEqual(
-                    len(actual_fields),
-                    len(set(actual_fields)),
-                    msg="Duplicates in the fields retrieved",
-                )
-
                 # verify that if there is a replication key we are doing INCREMENTAL otherwise FULL
                 if actual_replication_keys:
                     self.assertEqual(

--- a/tests/tap_tester/test_start_date.py
+++ b/tests/tap_tester/test_start_date.py
@@ -1,5 +1,4 @@
-import tap_tester.connections as connections
-import tap_tester.runner as runner
+from tap_tester import connections, runner, LOGGER
 from base import TestMixPanelBase
 
 
@@ -45,7 +44,7 @@ class MixPanelStartDateTest(TestMixPanelBase):
         # Update START DATE Between Syncs
         ##########################################################################
 
-        print("REPLICATION START DATE CHANGE: {} ===>>> {} ".format(
+        LOGGER.info("REPLICATION START DATE CHANGE: {} ===>>> {} ".format(
             self.start_date, self.start_date_2))
         self.start_date = self.start_date_2
 
@@ -150,8 +149,4 @@ class MixPanelStartDateTest(TestMixPanelBase):
     def test_run(self):
         #Start date test for standard server
         self.eu_residency = False
-        self.start_date_test_run()
-
-        #Start date test for EU recidency server
-        self.eu_residency = True
         self.start_date_test_run()


### PR DESCRIPTION
# Description of change
Integration tests have been failing from long and the main reason behind is that we are hitting rate limit **_mixpanel rate limit (170 queries per hour, or 5 concurrent requests)._**

Reduced API calls by removing the EU server API calls in bookmarks, start_date and automatic_fields test
# Manual QA steps
 - Ran all tests on dev-vm
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
