### PR TITLE
TDL-23384: Add retry for chunked encoding errors

### DIFF
--- a/tap_mixpanel/client.py
+++ b/tap_mixpanel/client.py
@@ -4,7 +4,7 @@ import backoff
 import jsonlines
 import requests
 import singer
-from requests.exceptions import ConnectionError, Timeout
+from requests.exceptions import ChunkedEncodingError, ConnectionError, Timeout
 from requests.models import ProtocolError
 from singer import metrics
 
@@ -204,7 +204,7 @@ class MixpanelClient:
 
     @backoff.on_exception(
         backoff.expo,
-        (Server5xxError, Server429Error, ReadTimeoutError, ConnectionError, Timeout, ProtocolError),
+        (Server5xxError, Server429Error, ReadTimeoutError, ConnectionError, Timeout, ProtocolError, ChunkedEncodingError),
         max_tries=BACKOFF_MAX_TRIES_REQUEST,
         factor=3,
         logger=LOGGER,

--- a/tap_mixpanel/client.py
+++ b/tap_mixpanel/client.py
@@ -302,6 +302,12 @@ class MixpanelClient:
         response_json = response.json()
         return response_json
 
+    @backoff.on_exception(
+        backoff.expo,
+        (Server5xxError, Server429Error, ReadTimeoutError, ConnectionError, Timeout, ProtocolError),
+        max_tries=5,
+        factor=2,
+    )
     def request_export(
         self, method, url=None, path=None, params=None, json=None, **kwargs
     ):

--- a/tap_mixpanel/client.py
+++ b/tap_mixpanel/client.py
@@ -302,12 +302,6 @@ class MixpanelClient:
         response_json = response.json()
         return response_json
 
-    @backoff.on_exception(
-        backoff.expo,
-        (Server5xxError, Server429Error, ReadTimeoutError, ConnectionError, Timeout, ProtocolError),
-        max_tries=5,
-        factor=2,
-    )
     def request_export(
         self, method, url=None, path=None, params=None, json=None, **kwargs
     ):


### PR DESCRIPTION
# Description of change
This PR adds retry logic to `perform_request` and `get_and_transform_records`.


# Manual QA steps
 - Ran the tap and looked for the log lines that we retried
 
# Risks
 - Low, it's just retry logic
 
# Rollback steps
 - revert this branch, bump the version
