### PR TITLE
Upgrade python version to 3.11.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-mixpanel/bin/activate
             pip install nose2
+            pip install parameterized
             nose2 -v -s tests/unittests
       - store_test_results:
           path: test_output/report.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
             source dev_env.sh
             python3 -m venv /usr/local/share/virtualenvs/tap-mixpanel
             source /usr/local/share/virtualenvs/tap-mixpanel/bin/activate
-            pip install -U 'pip<19.2' 'setuptools<51.0.0'
+            pip install -U 'pip==23.3.2' 'setuptools<51.0.0'
             pip install .[dev]
             pip install pytest-cov
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,8 @@ jobs:
           name: 'Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-mixpanel/bin/activate
-            pip install nose coverage parameterized
-            nosetests --with-coverage --cover-erase --cover-package=tap_mixpanel --cover-html-dir=htmlcov tests/unittests
+            pip install nose2
+            nose2 -v
       - store_test_results:
           path: test_output/report.xml
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester-3-11-dev
     steps:
       - checkout
       - add_ssh_keys

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-mixpanel/bin/activate
             pip install nose2
-            nose2 -v
+            nose2 -v -s tests/unittests
       - store_test_results:
           path: test_output/report.xml
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,9 +33,9 @@ jobs:
           name: 'Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-mixpanel/bin/activate
-            pip install nose2
+            pip install nose2 parameterized nose2[coverage_plugin]>=0.6.5
             pip install parameterized
-            nose2 -v -s tests/unittests
+            nose2 --with-coverage -v -s tests/unittests
       - store_test_results:
           path: test_output/report.xml
       - store_artifacts:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.6.0
+  * Requirement updates to run on python 3.11.7 [#63](https://github.com/singer-io/tap-mixpanel/pull/63)
+
 ## 1.5.1
   * Add retry logic for `ChunkedEncodingError`s [#61](https://github.com/singer-io/tap-mixpanel/pull/61)
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(name='tap-mixpanel',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_mixpanel'],
       install_requires=[
-          'backoff==1.8.0',
+          'backoff==2.2.1',
           'requests==2.22.0',
           'singer-python==5.12.1',
           'jsonlines==1.2.0'

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='tap-mixpanel',
       install_requires=[
           'backoff==2.2.1',
           'requests==2.22.0',
-          'singer-python==5.12.1',
+          'singer-python==6.0.0',
           'jsonlines==1.2.0'
       ],
       entry_points='''

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mixpanel',
-      version='1.5.1',
+      version='1.6.0',
       description='Singer.io tap for extracting data from the mixpanel API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
Necessary changes to requirements and testing config to run on python 3.11.7

# Manual QA steps
 - testing locally and in circle
 
# Risks
 - code not covered by tests could have incompatibilities with python 3.11 that we would not catch until released to prod. 
 
# Rollback steps
 - revert this branch
