### PR TITLE
make mp_reserved_insert_id available in export stream

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester-3-11-dev
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
     steps:
       - checkout
       - add_ssh_keys

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,8 @@ jobs:
          name: 'pylint tap'
          command: |
            source /usr/local/share/virtualenvs/tap-mixpanel/bin/activate
-           source dev_env.sh
            pip install pylint
-           pylint tap_mixpanel -d "$PYLINT_DISABLE_LIST,too-many-statements,protected-access,redefined-builtin"
+           pylint tap_mixpanel -d C,R,W
       - run:
           name: 'JSON Validator'
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.6.1
+  * Adds `mp_reserved_insert_id` field in export schema [#64](https://github.com/singer-io/tap-mixpanel/pull/64)
+  * Bump requests from 2.22.0 to 2.32.3
+
 ## 1.6.0
   * Requirement updates to run on python 3.11.7 [#63](https://github.com/singer-io/tap-mixpanel/pull/63)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.6.1
+## 1.7.0
   * Adds `mp_reserved_insert_id` field in export schema [#64](https://github.com/singer-io/tap-mixpanel/pull/64)
   * Bump requests from 2.22.0 to 2.32.3
 

--- a/setup.py
+++ b/setup.py
@@ -3,14 +3,14 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mixpanel',
-      version='1.6.0',
+      version='1.6.1',
       description='Singer.io tap for extracting data from the mixpanel API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_mixpanel'],
       install_requires=[
           'backoff==2.2.1',
-          'requests==2.22.0',
+          'requests==2.32.3',
           'singer-python==6.0.0',
           'jsonlines==1.2.0'
       ],

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mixpanel',
-      version='1.6.1',
+      version='1.7.0',
       description='Singer.io tap for extracting data from the mixpanel API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_mixpanel/schemas/export.json
+++ b/tap_mixpanel/schemas/export.json
@@ -12,6 +12,9 @@
       "type": ["null", "string"],
       "format": "date-time"
     },
+    "mp_reserved_insert_id": {
+      "type": ["null", "string"]
+    },
     "labels": {
       "anyOf": [
         {

--- a/tests/tap_tester/base.py
+++ b/tests/tap_tester/base.py
@@ -158,13 +158,17 @@ class TestMixPanelBase(BaseCase):
         # export stream endpoint returns 200 terminated early response.
         # So, as per discussion decided that let the customer come with the issues
         # that these streams are not working. Skip the streams in the circleci.
-        if self.eu_residency:
-            return set(self.expected_metadata().keys()) - {"export", "revenue"}
 
+        # Below are the streams for which we need to skip the tests as we need an upgraded plan to make API calls
+        UPGRADED_PLAN_STREAMS = {"annotations", "cohort_members", "cohorts", "export", "funnels"}
         self.assertNotEqual(JIRA_CLIENT.get_status_category('TDL-27055'),
                     'done',
-                    msg='JIRA ticket has moved to done, re-add the streams which are skipped below to expected_streams')
-        return set(self.expected_metadata().keys() - {"annotations", "cohort_members", "cohorts", "export", "funnels"})
+                    msg='JIRA ticket has moved to done, re-add the UPGRADED_PLAN_STREAMS which are skipped below to expected_streams')
+
+        if self.eu_residency:
+            return set(self.expected_metadata().keys()) - {"export", "revenue"} - UPGRADED_PLAN_STREAMS
+
+        return set(self.expected_metadata().keys()) - UPGRADED_PLAN_STREAMS
 
     def expected_pks(self):
         """Return a dictionary with key of table name and value as a set of primary key fields"""

--- a/tests/tap_tester/base.py
+++ b/tests/tap_tester/base.py
@@ -10,6 +10,10 @@ import dateutil.parser
 import pytz
 from tap_tester import LOGGER, connections, menagerie, runner
 from tap_tester.base_case import BaseCase
+from tap_tester.jira_client import JiraClient as jira_client
+from tap_tester.jira_client import CONFIGURATION_ENVIRONMENT as jira_config
+
+JIRA_CLIENT = jira_client({ **jira_config })
 
 
 class TestMixPanelBase(BaseCase):
@@ -157,7 +161,10 @@ class TestMixPanelBase(BaseCase):
         if self.eu_residency:
             return set(self.expected_metadata().keys()) - {"export", "revenue"}
 
-        return set(self.expected_metadata().keys())
+        self.assertNotEqual(JIRA_CLIENT.get_status_category('TDL-27055'),
+                    'done',
+                    msg='JIRA ticket has moved to done, re-add export stream to testable streams')
+        return set(self.expected_metadata().keys() - {"export"})
 
     def expected_pks(self):
         """Return a dictionary with key of table name and value as a set of primary key fields"""

--- a/tests/tap_tester/base.py
+++ b/tests/tap_tester/base.py
@@ -163,8 +163,8 @@ class TestMixPanelBase(BaseCase):
 
         self.assertNotEqual(JIRA_CLIENT.get_status_category('TDL-27055'),
                     'done',
-                    msg='JIRA ticket has moved to done, re-add export stream to testable streams')
-        return set(self.expected_metadata().keys() - {"export"})
+                    msg='JIRA ticket has moved to done, re-add the streams which are skipped below to expected_streams')
+        return set(self.expected_metadata().keys() - {"annotations", "cohort_members", "cohorts", "export", "funnels"})
 
     def expected_pks(self):
         """Return a dictionary with key of table name and value as a set of primary key fields"""

--- a/tests/tap_tester/test_mixpanel_all_fields_pagination.py
+++ b/tests/tap_tester/test_mixpanel_all_fields_pagination.py
@@ -1,6 +1,10 @@
 from math import ceil
 
 from tap_tester import connections, menagerie, runner
+from tap_tester.jira_client import JiraClient as jira_client
+from tap_tester.jira_client import CONFIGURATION_ENVIRONMENT as jira_config
+
+JIRA_CLIENT = jira_client({ **jira_config })
 
 from base import TestMixPanelBase
 
@@ -29,9 +33,12 @@ class MixPanelPaginationAllFieldsTest(TestMixPanelBase):
         that 251 (or more) records have been posted for that stream.
         """
 
-        # Only following below 2 streams support pagination
+        # Only these 2 streams ('engage' and 'cohort_members') support pagination
         streams_to_test_all_fields = self.expected_streams()
-        streams_to_test_pagination = {'engage', 'cohort_members'}
+        self.assertNotEqual(JIRA_CLIENT.get_status_category('TDL-27055'),
+                    'done',
+                    msg='JIRA ticket has moved to done, re-add the cohort_members in streams_to_test_pagination')
+        streams_to_test_pagination = {'engage'}
 
         expected_automatic_fields = self.expected_automatic_fields()
         conn_id = connections.ensure_connection(self)

--- a/tests/tap_tester/test_mixpanel_discovery.py
+++ b/tests/tap_tester/test_mixpanel_discovery.py
@@ -36,11 +36,10 @@ class MixPanelDiscoverTest(TestMixPanelBase):
         self.assertion_logging_enabled = True
 
         # Below are the streams for which we need to skip the tests as we need an upgraded plan to make API calls
-        UPGRADED_PLAN_STREAMS = {"annotations", "cohort_members", "cohorts", "export", "funnels"}
         self.assertNotEqual(JIRA_CLIENT.get_status_category('TDL-27055'),
                     'done',
                     msg='JIRA ticket has moved to done, remove the explicitly added streams in streams_to_test')
-        streams_to_test = self.expected_streams() | UPGRADED_PLAN_STREAMS
+        streams_to_test = self.expected_streams() | {"annotations", "cohort_members", "cohorts", "funnels"}
 
         conn_id = connections.ensure_connection(self, payload_hook=None)
 

--- a/tests/tap_tester/test_mixpanel_discovery.py
+++ b/tests/tap_tester/test_mixpanel_discovery.py
@@ -1,5 +1,9 @@
 import re
 from tap_tester import menagerie, connections, LOGGER
+from tap_tester.jira_client import JiraClient as jira_client
+from tap_tester.jira_client import CONFIGURATION_ENVIRONMENT as jira_config
+
+JIRA_CLIENT = jira_client({ **jira_config })
 
 from base import TestMixPanelBase
 
@@ -30,8 +34,10 @@ class MixPanelDiscoverTest(TestMixPanelBase):
         LOGGER.info(f"Testing against {region} account.")
 
         self.assertion_logging_enabled = True
-
-        streams_to_test = self.expected_streams()
+        self.assertNotEqual(JIRA_CLIENT.get_status_category('TDL-27055'),
+                    'done',
+                    msg='JIRA ticket has moved to done, remove the explicitly added streams in streams_to_test')
+        streams_to_test = self.expected_streams() + {"annotations", "cohort_members", "cohorts", "export", "funnels"}
 
         conn_id = connections.ensure_connection(self, payload_hook=None)
 

--- a/tests/tap_tester/test_mixpanel_discovery.py
+++ b/tests/tap_tester/test_mixpanel_discovery.py
@@ -34,10 +34,13 @@ class MixPanelDiscoverTest(TestMixPanelBase):
         LOGGER.info(f"Testing against {region} account.")
 
         self.assertion_logging_enabled = True
+
+        # Below are the streams for which we need to skip the tests as we need an upgraded plan to make API calls
+        UPGRADED_PLAN_STREAMS = {"annotations", "cohort_members", "cohorts", "export", "funnels"}
         self.assertNotEqual(JIRA_CLIENT.get_status_category('TDL-27055'),
                     'done',
                     msg='JIRA ticket has moved to done, remove the explicitly added streams in streams_to_test')
-        streams_to_test = self.expected_streams() + {"annotations", "cohort_members", "cohorts", "export", "funnels"}
+        streams_to_test = self.expected_streams() | UPGRADED_PLAN_STREAMS
 
         conn_id = connections.ensure_connection(self, payload_hook=None)
 

--- a/tests/tap_tester/test_mixpanel_discovery.py
+++ b/tests/tap_tester/test_mixpanel_discovery.py
@@ -39,6 +39,8 @@ class MixPanelDiscoverTest(TestMixPanelBase):
         self.assertNotEqual(JIRA_CLIENT.get_status_category('TDL-27055'),
                     'done',
                     msg='JIRA ticket has moved to done, remove the explicitly added streams in streams_to_test')
+        # The 'export' stream is not explicitly included here because generating the catalog requires making API calls.
+        # Currently, our plan does not include access to the necessary API, so we cannot make these calls.
         streams_to_test = self.expected_streams() | {"annotations", "cohort_members", "cohorts", "funnels"}
 
         conn_id = connections.ensure_connection(self, payload_hook=None)


### PR DESCRIPTION
# Description of change

1. Fixes https://github.com/singer-io/tap-mixpanel/issues/23
2. Dependabot fixes for https://github.com/singer-io/tap-mixpanel/security/dependabot/1 https://github.com/singer-io/tap-mixpanel/security/dependabot/2

# Manual QA steps
 - Tested the changes by doing pr-alpha and they're working fine.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
