### PR TITLE
Remove required False from engage schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.7.1
+  * Remove `required: False` for engage schema  [#65](https://github.com/singer-io/tap-mixpanel/pull/65)
+
 ## 1.7.0
   * Adds `mp_reserved_insert_id` field in export schema [#64](https://github.com/singer-io/tap-mixpanel/pull/64)
   * Bump requests from 2.22.0 to 2.32.3

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mixpanel',
-      version='1.7.0',
+      version='1.7.1',
       description='Singer.io tap for extracting data from the mixpanel API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_mixpanel/__init__.py
+++ b/tap_mixpanel/__init__.py
@@ -85,7 +85,7 @@ def main():
         config = parsed_args.config
         client.__api_domain = api_domain
         properties_flag = config.get("select_properties_by_default")
-
+        LOGGER.info("On test branch hi")
         if parsed_args.discover:
             do_discover(client, properties_flag)
         else:

--- a/tap_mixpanel/__init__.py
+++ b/tap_mixpanel/__init__.py
@@ -85,7 +85,7 @@ def main():
         config = parsed_args.config
         client.__api_domain = api_domain
         properties_flag = config.get("select_properties_by_default")
-        LOGGER.info("On test branch hi")
+
         if parsed_args.discover:
             do_discover(client, properties_flag)
         else:

--- a/tap_mixpanel/schema.py
+++ b/tap_mixpanel/schema.py
@@ -90,7 +90,6 @@ def get_schema(client, properties_flag, stream_name):
                     },
                     "list": {
                         "type": ["null", "array"],
-                        "required": False,
                         "items": {}},
                     "string": {
                         "type": ["null", "string"]},


### PR DESCRIPTION
# Description of change
Removing `"required" : False` for lists as it is breaking the extraction job with this error: `Target failed with code 1 and error message: "required must be an array".` We checked the json schema library and confirmed that the default value for required is an empty array, so the false value is not needed in the code.
https://qlik-dev.atlassian.net/browse/TDL-27061

# Manual QA steps
 - Tested it locally and was able to successfully run extractions
 
# Risks
 - This will update the `engage` schema but should not cause any meaningful changes
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
