### PR TITLE
[SAC-28860] - `parent-tap-stream-id` in metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.7.3
+## 1.8.0
   * Add `parent-tap-stream-id` field to stream metadata for child streams [#70](https://github.com/singer-io/tap-mixpanel/pull/70)
 
 ## 1.7.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.7.3
+  * Add `parent-tap-stream-id` field to stream metadata for child streams [#70](https://github.com/singer-io/tap-mixpanel/pull/70)
+
 ## 1.7.2
   * Bump dependency versions for twistlock compliance
   * Update tests to pass circle build

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mixpanel',
-      version='1.7.3',
+      version='1.8.0',
       description='Singer.io tap for extracting data from the mixpanel API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mixpanel',
-      version='1.7.2',
+      version='1.7.3',
       description='Singer.io tap for extracting data from the mixpanel API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ setup(name='tap-mixpanel',
       py_modules=['tap_mixpanel'],
       install_requires=[
           'backoff==2.2.1',
-          'requests==2.32.4',
-          'singer-python==6.0.1',
+          'requests==2.34.2',
+          'singer-python==6.8.0',
           'jsonlines==1.2.0'
       ],
       entry_points='''

--- a/tap_mixpanel/schema.py
+++ b/tap_mixpanel/schema.py
@@ -186,6 +186,10 @@ def get_schemas(client, properties_flag):
                 "automatic",
             )
 
+        parent_tap_stream_id = getattr(stream_metadata, "parent", None)
+        if parent_tap_stream_id:
+            mdata = metadata.write(mdata, (), 'parent-tap-stream-id', parent_tap_stream_id)
+
         mdata = metadata.to_list(mdata)
 
         field_metadata[stream_name] = mdata

--- a/tests/tap_tester/base.py
+++ b/tests/tap_tester/base.py
@@ -25,6 +25,7 @@ class TestMixPanelBase(BaseCase):
     PRIMARY_KEYS = "table-key-properties"
     FOREIGN_KEYS = "table-foreign-key-properties"
     REPLICATION_METHOD = "forced-replication-method"
+    PARENT_STREAM_ID = "parent-tap-stream-id"
     INCREMENTAL = "INCREMENTAL"
     FULL_TABLE = "FULL_TABLE"
     API_LIMIT = 250
@@ -68,6 +69,7 @@ class TestMixPanelBase(BaseCase):
                 self.PRIMARY_KEYS: {"cohort_id", "distinct_id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.OBEYS_START_DATE: True,
+                self.PARENT_STREAM_ID: "cohorts",
             },
             "revenue": {
                 self.PRIMARY_KEYS: {"date"},
@@ -202,7 +204,9 @@ class TestMixPanelBase(BaseCase):
     def expected_parent_stream_ids(self):
         """Return a dictionary with key of stream name and value as parent stream id if applicable"""
         return {
-            "cohort_members": "cohorts",
+            table: properties.get(self.PARENT_STREAM_ID)
+            for table, properties in self.expected_metadata().items()
+            if properties.get(self.PARENT_STREAM_ID) is not None
         }
 
     #########################

--- a/tests/tap_tester/base.py
+++ b/tests/tap_tester/base.py
@@ -199,6 +199,12 @@ class TestMixPanelBase(BaseCase):
             )
         return auto_fields
 
+    def expected_parent_stream_ids(self):
+        """Return a dictionary with key of stream name and value as parent stream id if applicable"""
+        return {
+            "cohort_members": "cohorts",
+        }
+
     #########################
     #   Helper Methods      #
     #########################

--- a/tests/tap_tester/test_mixpanel_discovery.py
+++ b/tests/tap_tester/test_mixpanel_discovery.py
@@ -108,7 +108,7 @@ class MixPanelDiscoverTest(TestMixPanelBase):
                 actual_parent_stream_id = (
                     stream_properties[0]
                     .get("metadata", {})
-                    .get("parent-tap-stream-id")
+                    .get(self.PARENT_STREAM_ID)
                 )
 
                 actual_fields = []
@@ -181,7 +181,7 @@ class MixPanelDiscoverTest(TestMixPanelBase):
                 self.assertEqual(
                     expected_parent_stream_id,
                     actual_parent_stream_id,
-                    logging=f"asserting parent-tap-stream-id is {expected_parent_stream_id}",
+                    logging=f"asserting {self.PARENT_STREAM_ID} is {expected_parent_stream_id}",
                 )
 
                 # Verify that all other fields have inclusion of available.

--- a/tests/tap_tester/test_mixpanel_discovery.py
+++ b/tests/tap_tester/test_mixpanel_discovery.py
@@ -75,6 +75,7 @@ class MixPanelDiscoverTest(TestMixPanelBase):
                 expected_replication_keys = self.expected_replication_keys()[stream]
                 expected_automatic_fields = self.expected_automatic_fields().get(stream)
                 expected_replication_method = self.expected_replication_method()[stream]
+                expected_parent_stream_id = self.expected_parent_stream_ids().get(stream)
 
                 # Collecting actual values...
                 schema_and_metadata = menagerie.get_annotated_schema(
@@ -104,6 +105,11 @@ class MixPanelDiscoverTest(TestMixPanelBase):
                     for item in metadata
                     if item.get("metadata").get("inclusion") == "automatic"
                 }
+                actual_parent_stream_id = (
+                    stream_properties[0]
+                    .get("metadata", {})
+                    .get("parent-tap-stream-id")
+                )
 
                 actual_fields = []
                 for md_entry in metadata:
@@ -169,6 +175,13 @@ class MixPanelDiscoverTest(TestMixPanelBase):
                     expected_automatic_fields,
                     actual_automatic_fields,
                     logging=f"asserting primary and replication keys {expected_automatic_fields} are automatic",
+                )
+
+                # Verify parent-tap-stream-id metadata if applicable
+                self.assertEqual(
+                    expected_parent_stream_id,
+                    actual_parent_stream_id,
+                    logging=f"asserting parent-tap-stream-id is {expected_parent_stream_id}",
                 )
 
                 # Verify that all other fields have inclusion of available.

--- a/tests/unittests/test_request_timeout_param_value.py
+++ b/tests/unittests/test_request_timeout_param_value.py
@@ -51,7 +51,7 @@ HEADER = {
 }
 
 
-@mock.patch("requests.Session.request", return_value=Mockresponse("", status_code=200))
+@mock.patch("requests.Session.get", return_value=Mockresponse("", status_code=200))
 @mock.patch("singer.utils.parse_args")
 @mock.patch("tap_mixpanel.__init__.do_discover", return_value="")
 class TestMixpanelRequestTimeoutParameterValue(unittest.TestCase):
@@ -72,9 +72,7 @@ class TestMixpanelRequestTimeoutParameterValue(unittest.TestCase):
 
         # Verify that request method called with expected parameter value when"request_timeout" is None
         mock_request.assert_called_with(
-            "GET",
-            "https://mixpanel.com/api/2.0/engage",
-            allow_redirects=True,
+            url="https://mixpanel.com/api/2.0/engage",
             headers=HEADER,
             timeout=REQUEST_TIMEOUT_DEFAULT,
         )
@@ -102,9 +100,7 @@ class TestMixpanelRequestTimeoutParameterValue(unittest.TestCase):
 
         # Verify that request method called with expected parameter value
         mock_request.assert_called_with(
-            "GET",
-            "https://mixpanel.com/api/2.0/engage",
-            allow_redirects=True,
+            url="https://mixpanel.com/api/2.0/engage",
             headers=HEADER,
             timeout=expected_value,
         )

--- a/tests/unittests/test_support_eu_endpoints.py
+++ b/tests/unittests/test_support_eu_endpoints.py
@@ -190,7 +190,7 @@ class TestMixpanelSupportEuEndpoints(unittest.TestCase):
             endpoint="export",
         )
 
-    @mock.patch("requests.Session.request")
+    @mock.patch("requests.Session.get")
     @mock.patch("singer.utils.parse_args")
     @mock.patch("tap_mixpanel.__init__.do_discover")
     def test_support_eu_endpoint_in_discover(
@@ -217,9 +217,7 @@ class TestMixpanelSupportEuEndpoints(unittest.TestCase):
 
         # Verify that with EU config, base url has eu-domain.
         mock_request.assert_called_with(
-            "GET",
-            "https://eu.mixpanel.com/api/2.0/engage",
-            allow_redirects=True,
+            url="https://eu.mixpanel.com/api/2.0/engage",
             headers=header,
             timeout=300,
         )
@@ -231,9 +229,7 @@ class TestMixpanelSupportEuEndpoints(unittest.TestCase):
 
         # Verify that with standard config, base URL has default domain.
         mock_request.assert_called_with(
-            "GET",
-            "https://mixpanel.com/api/2.0/engage",
-            allow_redirects=True,
+            url="https://mixpanel.com/api/2.0/engage",
             headers=header,
             timeout=300,
         )

--- a/tests/unittests/test_transform_event_times.py
+++ b/tests/unittests/test_transform_event_times.py
@@ -25,7 +25,7 @@ class TestTransformEventTimes(unittest.TestCase):
 
         actual = transform_event_times(record, project_timezone)
         expected = {
-            "time": input_time.astimezone(UTC).strftime("%04Y-%m-%dT%H:%M:%S.000000Z")
+            "time": input_time.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%S.000000Z")
         }
 
         # Verify that record uis converted as expected.
@@ -45,7 +45,7 @@ class TestTransformEventTimes(unittest.TestCase):
         actual = transform_event_times(record, project_timezone)
 
         expected = {
-            "time": input_time.astimezone(UTC).strftime("%04Y-%m-%dT%H:%M:%S.000000Z")
+            "time": input_time.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%S.000000Z")
         }
 
         # Verify that record uis converted as expected.


### PR DESCRIPTION
# Description of change
Ticket: **https://qlik-dev.atlassian.net/browse/SAC-28860**

> **Add `parent-tap-stream-id` field to stream metadata**

This PR enhances `tap-mixpanel` by injecting metadata property `parent-tap-stream-id` into the stream metadata schema.

# Rollback steps
 - revert this branch

